### PR TITLE
Make syslog.LOG_PERROR optional

### DIFF
--- a/cef.py
+++ b/cef.py
@@ -40,8 +40,11 @@ try:
     _SYSLOG_OPTIONS = {'PID': syslog.LOG_PID,
                        'CONS': syslog.LOG_CONS,
                        'NDELAY': syslog.LOG_NDELAY,
-                       'NOWAIT': syslog.LOG_NOWAIT,
-                       'PERROR': syslog.LOG_PERROR}
+                       'NOWAIT': syslog.LOG_NOWAIT}
+
+    # LOG_PERROR is undefined on some platforms, e.g. solaris
+    if hasattr(syslog, 'LOG_PERROR'):
+        _SYSLOG_OPTIONS['PERROR'] = syslog.LOG_PERROR
 
     _SYSLOG_PRIORITY = {'EMERG': syslog.LOG_EMERG,
                         'ALERT': syslog.LOG_ALERT,


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=779371

LOG_PERROR is not defined on all platforms, this patch checks for its existence before sucking it into the _SYSLOG_OPTIONS dict.
